### PR TITLE
Update airbnb config and import plugin and add test script

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "description": "ESLint config for Netlife Research projects",
   "main": "index.js",
   "scripts": {
+    "test": "npm run lint",
     "lint": "eslint ."
   },
   "repository": {
@@ -21,18 +22,18 @@
   },
   "homepage": "https://github.com/netliferesearch/eslint-config-netliferesearch#readme",
   "dependencies": {
-    "lodash.merge": "^4.3.5",
-    "eslint-config-airbnb": "^10.0.0"
+    "eslint-config-airbnb": "^12.0.0",
+    "lodash.merge": "^4.3.5"
   },
   "peerDependencies": {
     "eslint": "^3.2.2",
-    "eslint-plugin-import": "^1.12.0",
+    "eslint-plugin-import": "^2.0.1",
     "eslint-plugin-jsx-a11y": "^2.0.1",
     "eslint-plugin-react": "^6.0.0"
   },
   "devDependencies": {
     "eslint": "^3.2.2",
-    "eslint-plugin-import": "^1.12.0",
+    "eslint-plugin-import": "^2.0.1",
     "eslint-plugin-jsx-a11y": "^2.0.1",
     "eslint-plugin-react": "^6.0.0"
   }


### PR DESCRIPTION
@fredjens @kbrabrand I'm getting this warning and thought bumping the dependencies would help. Looks like most of the breaking changes are additions of rules [CHANGELOG](https://github.com/airbnb/javascript/blob/master/packages/eslint-config-airbnb/CHANGELOG.md).

``` bash
The react/require-extension rule is deprecated. Please use the import/extensions rule from eslint-plugin-import instead.
```

I also added the `npm test` command. The only thing is does is that it runes the `npm run lint` command. 

Don't know how you version the package but I can add a new version to this PR if it is needed =)
